### PR TITLE
Enforce upload limits during streaming uploads

### DIFF
--- a/app/storage/base.py
+++ b/app/storage/base.py
@@ -2,6 +2,7 @@
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
+from typing import AsyncIterator
 
 
 @dataclass
@@ -29,6 +30,28 @@ class StorageBackend(ABC):
 
         Args:
             file_data: Raw file bytes
+            filename: Original filename (will be sanitized)
+            content_type: MIME type of the file
+            owner_id: Optional owner ID for organizing files
+
+        Returns:
+            UploadResult with storage path, public URL, and size
+        """
+        pass
+
+    @abstractmethod
+    async def upload_stream(
+        self,
+        file_stream: AsyncIterator[bytes],
+        filename: str,
+        content_type: str,
+        owner_id: str | None = None,
+    ) -> UploadResult:
+        """
+        Upload a file to storage from an async byte stream.
+
+        Args:
+            file_stream: Async iterator yielding file chunks
             filename: Original filename (will be sanitized)
             content_type: MIME type of the file
             owner_id: Optional owner ID for organizing files


### PR DESCRIPTION
### Motivation
- Prevent streaming uploads from exceeding per-file and per-account storage limits by enforcing quotas before and during the stream.
- Avoid wasted work and storage inconsistency by aborting/rolling back uploads that exceed quota or configured max size.
- Provide a clear HTTP status for quota exhaustion during streaming so callers can distinguish size vs quota failures.

### Description
- Add `upload_stream` to the storage backend interface (`app/storage/base.py`) as an abstract method that accepts an `AsyncIterator[bytes]` and returns `UploadResult`.
- Implement streaming uploads for local storage in `app/storage/local.py` with chunked writes, size accounting, and cleanup on error using `upload_stream`.
- Implement multipart streaming uploads for S3 in `app/storage/s3.py` with a `_MIN_PART_SIZE` (5MB), `create_multipart_upload`/`upload_part`/`complete_multipart_upload` flow and `abort_multipart_upload` on failure, and return a proper `UploadResult`.
- Update `app/routes/media.py` to stream the incoming `UploadFile` in ~1MB chunks, pre-check and compute an `upload_limit` based on `MAX_UPLOAD_SIZE_MB` and the user's remaining quota, raise `UploadLimitError` (mapped to `402`) for quota exhaustion mid-stream and `UploadTooLargeError` (`413`) for exceeding the configured per-file size, call `storage.upload_stream`, and enforce the post-upload quota check with cleanup (`storage.delete`) on quota violations.
- Add `UploadLimitError` to carry HTTP status and detail so quota-exceeded errors can return a `402` response.

### Testing
- Ran the test suite with `pytest` (collected 350 items); the run produced `184 passed, 7 failed, 136 errors, 23 skipped`.
- Many errors are from E2E Playwright tests failing because Playwright browsers are not installed in the environment (error: `BrowserType.launch: Executable doesn't exist`, suggesting `playwright install` is required), and `tests/integration/test_webhooks.py` showed failures; unit/integration media tests executed and media-related tests passed where not dependent on Playwright.
- No additional automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984aa5c59308320b8e90065056e6cf7)