### PR TITLE
Add config-driven iframe embedding for demo screen

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -49,6 +49,18 @@ SQLITE_PATH=data/screens.db
 # USAGE_LOG_FILE_PATH=logs/usage.log
 
 # =============================================================================
+# IFRAME EMBEDDING (demo screen only)
+# =============================================================================
+# Allow specific screens to be embedded via <iframe> from an allowlist of parent
+# origins (e.g. a marketing site). Leave both empty to keep every screen
+# unframeable (frame-ancestors 'none' + X-Frame-Options: SAMEORIGIN) — the default.
+#
+# Space/comma-separated parent origins (exact scheme+host) allowed to frame:
+# EMBED_ALLOWED_ORIGINS=https://bigbeautifulscreens.com https://www.bigbeautifulscreens.com
+# Comma/space-separated screen IDs permitted to be framed (e.g. the demo screen):
+# EMBED_SCREEN_IDS=abc123def456
+
+# =============================================================================
 # MEDIA STORAGE
 # =============================================================================
 # Storage backend: local, s3, or r2

--- a/app/config.py
+++ b/app/config.py
@@ -87,6 +87,10 @@ class Settings(BaseSettings):
     # Debug logging
     AUTH_DEBUG: bool = False
 
+    # Iframe embedding (config-driven, demo screen only). Both empty = feature off.
+    EMBED_ALLOWED_ORIGINS: str = ""  # space/comma-separated parent origins allowed to frame
+    EMBED_SCREEN_IDS: str = ""  # comma/space-separated screen IDs permitted to be framed
+
     class Config:
         env_file = ".env"
         case_sensitive = True
@@ -100,6 +104,16 @@ class Settings(BaseSettings):
     def is_self_hosted(self) -> bool:
         """Check if running in self-hosted mode."""
         return self.APP_MODE == AppMode.SELF_HOSTED
+
+    @property
+    def embed_allowed_origins(self) -> list[str]:
+        """Parent origins allowed to frame embeddable screens (empty = none)."""
+        return [o for o in self.EMBED_ALLOWED_ORIGINS.replace(",", " ").split() if o]
+
+    @property
+    def embed_screen_ids(self) -> set[str]:
+        """Screen IDs permitted to be framed cross-origin (empty = none)."""
+        return {s for s in self.EMBED_SCREEN_IDS.replace(",", " ").split() if s}
 
     def validate_saas_config(self) -> list[str]:
         """Validate that required SaaS settings are present. Returns list of missing settings."""

--- a/app/main.py
+++ b/app/main.py
@@ -60,7 +60,10 @@ async def add_security_headers(request: Request, call_next):
     response.headers.setdefault("X-Content-Type-Options", "nosniff")
     response.headers.setdefault("Referrer-Policy", "strict-origin-when-cross-origin")
     response.headers.setdefault("Permissions-Policy", "geolocation=(), microphone=(), camera=()")
-    response.headers.setdefault("X-Frame-Options", "SAMEORIGIN")
+    # Embeddable screens opt out of X-Frame-Options (set via request.state by the
+    # screen viewer) so it doesn't conflict with their CSP frame-ancestors allowlist.
+    if not getattr(request.state, "allow_embed", False):
+        response.headers.setdefault("X-Frame-Options", "SAMEORIGIN")
 
     proto = request.headers.get("x-forwarded-proto", request.url.scheme)
     if proto == "https":

--- a/app/routes/screens.py
+++ b/app/routes/screens.py
@@ -52,18 +52,25 @@ router = APIRouter(tags=["Screens"])
 
 static_path = Path(__file__).parent.parent.parent / "static"
 
-SCREEN_CSP = (
-    "default-src 'self'; "
-    "script-src 'self' https://cdn.jsdelivr.net https://static.cloudflareinsights.com; "
-    "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
-    "img-src 'self' data: https:; "
-    "media-src 'self' https: blob:; "
-    "font-src 'self' https://fonts.gstatic.com data:; "
-    "connect-src 'self' ws: wss:; "
-    "object-src 'none'; "
-    "base-uri 'self'; "
-    "frame-ancestors 'none'"
-)
+
+def build_screen_csp(frame_ancestors: str = "'none'") -> str:
+    """Build the screen-viewer CSP. Defaults to blocking all framing.
+
+    `frame_ancestors` is the value for the frame-ancestors directive, e.g.
+    "'none'" (default) or a space-separated origin allowlist for embeddable screens.
+    """
+    return (
+        "default-src 'self'; "
+        "script-src 'self' https://cdn.jsdelivr.net https://static.cloudflareinsights.com; "
+        "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
+        "img-src 'self' data: https:; "
+        "media-src 'self' https: blob:; "
+        "font-src 'self' https://fonts.gstatic.com data:; "
+        "connect-src 'self' ws: wss:; "
+        "object-src 'none'; "
+        "base-uri 'self'; "
+        f"frame-ancestors {frame_ancestors}"
+    )
 
 
 # ============== Screen Endpoints ==============
@@ -869,15 +876,27 @@ async def reorder_pages_endpoint(
 
 
 @router.get("/screen/{screen_id}", response_class=HTMLResponse, include_in_schema=False)
-async def view_screen(screen_id: str):
+async def view_screen(screen_id: str, request: Request):
     """Serve the screen viewer page."""
     screen = await get_screen_by_id(screen_id)
     if not screen:
         raise HTTPException(status_code=404, detail="Screen not found")
 
+    # Config-driven embedding: a screen listed in EMBED_SCREEN_IDS (with a
+    # non-empty origin allowlist) may be framed by those origins. All other
+    # screens stay locked to frame-ancestors 'none'.
+    settings = get_settings()
+    if screen_id in settings.embed_screen_ids and settings.embed_allowed_origins:
+        frame_ancestors = " ".join(settings.embed_allowed_origins)
+        # Signal the security-headers middleware to omit X-Frame-Options, which
+        # cannot express a multi-origin allowlist and would conflict otherwise.
+        request.state.allow_embed = True
+    else:
+        frame_ancestors = "'none'"
+
     html_path = static_path / "screen.html"
     response = HTMLResponse(content=html_path.read_text())
-    response.headers["Content-Security-Policy"] = SCREEN_CSP
+    response.headers["Content-Security-Policy"] = build_screen_csp(frame_ancestors)
     return response
 
 

--- a/docs/superpowers/specs/2026-06-22-embeddable-demo-screen-design.md
+++ b/docs/superpowers/specs/2026-06-22-embeddable-demo-screen-design.md
@@ -1,0 +1,86 @@
+# Embeddable Demo Screen — Design Spec
+
+**Date:** 2026-06-22
+**Branch:** `feature/embeddable-demo-screen`
+**Status:** Approved
+
+## Problem
+
+The marketing website needs to embed a live BBS demo screen via `<iframe>`. Today every screen is unframeable from other origins:
+
+- `app/main.py:63` — global middleware sets `X-Frame-Options: SAMEORIGIN` on all responses.
+- `app/routes/screens.py:55-66, 880` — the `/screen/{id}` viewer attaches `SCREEN_CSP` ending in `frame-ancestors 'none'`.
+
+`X-Frame-Options` cannot express a multi-origin allowlist, and `SAMEORIGIN` keeps blocking cross-origin frames even if the CSP is relaxed. Modern browsers honor CSP `frame-ancestors` and ignore XFO when both are present — but the safe approach is to omit XFO entirely on the embeddable response so there is no conflict.
+
+## Goal
+
+Allow a specific, configured demo screen to be framed from an allowlist of marketing origins. Every other screen — and all self-hosted installs by default — stays locked to `frame-ancestors 'none'`. No database schema change.
+
+## Non-goals
+
+Per-screen `embeddable` flag, admin UI, customer-facing embedding, a dedicated `/embed/{id}` route. Demo-only, config-driven.
+
+## Design
+
+### 1. Config (`app/config.py` `Settings`)
+
+Two new env-var settings, both raw strings (avoids pydantic JSON-list parsing), with parsed accessors:
+
+- `EMBED_ALLOWED_ORIGINS: str = ""` — space/comma-separated parent origins allowed to frame.
+- `EMBED_SCREEN_IDS: str = ""` — comma-separated screen IDs permitted to be framed.
+- `embed_allowed_origins -> list[str]` and `embed_screen_ids -> set[str]` properties parse/normalize (split on whitespace+comma, strip, drop empties).
+
+**Both empty/unset → feature off.** This is the default for self-hosted and for any environment that hasn't opted in — behavior identical to today.
+
+### 2. CSP builder (`app/routes/screens.py`)
+
+Replace the `SCREEN_CSP` constant with `build_screen_csp(frame_ancestors: str = "'none'") -> str` returning the same policy string with the given `frame-ancestors` value. Default call reproduces today's policy exactly.
+
+### 3. `view_screen` logic
+
+Add `request: Request` to the signature. After loading the screen:
+
+```
+settings = get_settings()
+is_embeddable = screen_id in settings.embed_screen_ids and bool(settings.embed_allowed_origins)
+if is_embeddable:
+    frame_ancestors = " ".join(settings.embed_allowed_origins)
+    request.state.allow_embed = True
+else:
+    frame_ancestors = "'none'"
+response.headers["Content-Security-Policy"] = build_screen_csp(frame_ancestors)
+```
+
+`frame-ancestors` with multiple origins is space-separated.
+
+### 4. Middleware drops XFO for embeddable responses (`app/main.py`)
+
+The middleware runs *after* the route handler, so deleting XFO in the route would be re-added by `setdefault`. Instead, gate it:
+
+```
+if not getattr(request.state, "allow_embed", False):
+    response.headers.setdefault("X-Frame-Options", "SAMEORIGIN")
+```
+
+Embeddable responses therefore carry no `X-Frame-Options` header. Modern browsers enforce `frame-ancestors`; legacy XFO-only browsers fail safe (block).
+
+## Testing (`tests/core/unit`, hermetic)
+
+1. **Default screen** → CSP contains `frame-ancestors 'none'` **and** header `X-Frame-Options: SAMEORIGIN`.
+2. **Configured embeddable screen** (env set, screen ID in allowlist) → CSP contains the configured origins, contains no `'none'` for frame-ancestors, and response has **no** `X-Frame-Options` header.
+3. **Non-configured screen while allowlist set** → still `frame-ancestors 'none'` + XFO present.
+4. **Empty config** → everything locked (feature off).
+
+Tests clear the `get_settings` lru_cache and set env vars (matching existing unit-test conventions).
+
+## Rollout (Railway env vars, post-merge)
+
+Set per environment via Railway MCP using each environment's real demo-screen ID:
+
+- **dev**: `EMBED_ALLOWED_ORIGINS` = `https://bigbeautifulscreens.com https://www.bigbeautifulscreens.com https://dev.big-beautiful-screens-web.pages.dev`; `EMBED_SCREEN_IDS` = dev demo screen ID.
+- **prod**: `EMBED_ALLOWED_ORIGINS` = `https://bigbeautifulscreens.com https://www.bigbeautifulscreens.com` (add the pages.dev preview only if the preview marketing site frames the prod backend); `EMBED_SCREEN_IDS` = prod demo screen ID.
+
+## Tradeoff
+
+Gating by screen ID means if the demo screen is recreated (new ID), `EMBED_SCREEN_IDS` must be updated. Acceptable for a stable public demo.

--- a/tests/core/unit/test_embed_headers.py
+++ b/tests/core/unit/test_embed_headers.py
@@ -1,0 +1,125 @@
+"""Tests for iframe-embedding security headers on the screen viewer.
+
+Covers the config-driven embeddable-demo-screen feature: a screen whose ID is
+listed in EMBED_SCREEN_IDS (with a non-empty EMBED_ALLOWED_ORIGINS) is served
+with a relaxed CSP frame-ancestors allowlist and no X-Frame-Options header.
+Every other screen stays locked to frame-ancestors 'none' + X-Frame-Options.
+"""
+
+import os
+import tempfile
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup_test_db() -> Iterator:
+    """Set up a temporary database for testing."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.environ["SQLITE_PATH"] = str(Path(tmpdir) / "test_embed.db")
+
+        from app.config import get_settings
+
+        get_settings.cache_clear()
+
+        from app.db.factory import reset_database
+
+        reset_database()
+
+        import asyncio
+        import concurrent.futures
+
+        import app.database as db_module
+        from app.main import app
+
+        try:
+            asyncio.get_running_loop()
+            with concurrent.futures.ThreadPoolExecutor() as executor:
+                executor.submit(asyncio.run, db_module.init_db()).result()
+        except RuntimeError:
+            asyncio.run(db_module.init_db())
+
+        yield app
+
+        reset_database()
+        get_settings.cache_clear()
+
+
+@pytest.fixture
+def client(setup_test_db) -> TestClient:
+    return TestClient(setup_test_db)
+
+
+@pytest.fixture
+def screen_id(client) -> str:
+    """Create a screen and return its id."""
+    response = client.post("/api/v1/screens")
+    assert response.status_code == 200
+    return response.json()["screen_id"]
+
+
+ORIGINS = "https://bigbeautifulscreens.com https://www.bigbeautifulscreens.com"
+
+
+@pytest.fixture
+def embed_env() -> Iterator[None]:
+    """Context where EMBED_* env vars are set; cleaned up + cache cleared after."""
+    from app.config import get_settings
+
+    def _apply(screen_ids: str, origins: str) -> None:
+        os.environ["EMBED_SCREEN_IDS"] = screen_ids
+        os.environ["EMBED_ALLOWED_ORIGINS"] = origins
+        get_settings.cache_clear()
+
+    yield _apply
+
+    os.environ.pop("EMBED_SCREEN_IDS", None)
+    os.environ.pop("EMBED_ALLOWED_ORIGINS", None)
+    get_settings.cache_clear()
+
+
+class TestDefaultLockedDown:
+    """With no embed config, all screens stay unframeable (current behavior)."""
+
+    def test_default_screen_blocks_framing(self, client, screen_id):
+        resp = client.get(f"/screen/{screen_id}")
+        assert resp.status_code == 200
+        assert "frame-ancestors 'none'" in resp.headers["content-security-policy"]
+        assert resp.headers.get("x-frame-options") == "SAMEORIGIN"
+
+
+class TestEmbeddableScreen:
+    """A configured demo screen is framable from the allowlist; no XFO."""
+
+    def test_configured_screen_allows_allowlisted_origins(self, client, screen_id, embed_env):
+        embed_env(screen_ids=screen_id, origins=ORIGINS)
+        resp = client.get(f"/screen/{screen_id}")
+        assert resp.status_code == 200
+        csp = resp.headers["content-security-policy"]
+        assert (
+            "frame-ancestors https://bigbeautifulscreens.com https://www.bigbeautifulscreens.com"
+            in csp
+        )
+        assert "frame-ancestors 'none'" not in csp
+        # XFO must be absent so it doesn't conflict with the frame-ancestors allowlist.
+        assert "x-frame-options" not in {k.lower() for k in resp.headers}
+
+    def test_other_screen_stays_locked_while_allowlist_set(self, client, embed_env):
+        """Only screens in EMBED_SCREEN_IDS are embeddable; others stay 'none'."""
+        embeddable = client.post("/api/v1/screens").json()["screen_id"]
+        other = client.post("/api/v1/screens").json()["screen_id"]
+        embed_env(screen_ids=embeddable, origins=ORIGINS)
+
+        resp = client.get(f"/screen/{other}")
+        assert "frame-ancestors 'none'" in resp.headers["content-security-policy"]
+        assert resp.headers.get("x-frame-options") == "SAMEORIGIN"
+
+    def test_screen_id_listed_but_no_origins_stays_locked(self, client, screen_id, embed_env):
+        """An allowlisted screen ID with empty origins is still locked (feature off)."""
+        embed_env(screen_ids=screen_id, origins="")
+        resp = client.get(f"/screen/{screen_id}")
+        assert "frame-ancestors 'none'" in resp.headers["content-security-policy"]
+        assert resp.headers.get("x-frame-options") == "SAMEORIGIN"


### PR DESCRIPTION
## Summary
- Add config-driven iframe embedding support for the demo screen (`app/config.py`, `app/routes/screens.py`, `app/main.py`)
- Add `.env.example` entries for embed configuration
- Add design spec and unit tests covering embed headers (default locked-down framing behavior)

## Test Plan
- [x] `pytest tests/core/unit` — 216 passed
- [x] `pytest tests/saas/unit` — 34 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)