### PR TITLE
Post bbs-screen-ready message to parent on first render

### DIFF
--- a/static/screen.js
+++ b/static/screen.js
@@ -88,6 +88,20 @@ let debugEnabled = localStorage.getItem('debugEnabled') === 'true';
 // Active widget elements for cleanup
 let activeWidgets = [];
 
+// Notify an embedding parent (e.g. marketing site iframe) that the screen has
+// rendered its first content. Fired at most once. When not framed,
+// window.parent === window, so this is a harmless self-post.
+let screenReadySignaled = false;
+function signalScreenReady() {
+    if (screenReadySignaled) return;
+    screenReadySignaled = true;
+    try {
+        window.parent.postMessage({ type: 'bbs-screen-ready' }, '*');
+    } catch (e) {
+        // postMessage can throw in some sandboxed contexts; ignore.
+    }
+}
+
 // Initialize
 connect();
 
@@ -558,6 +572,8 @@ function renderCurrentPage() {
         // No pages to show
         screenEl.innerHTML = '<div class="panel"><div class="panel-content"><div class="content-text">No content</div></div></div>';
         screenEl.className = 'screen panels-1';
+        // The screen booted and painted (empty) — still signal readiness.
+        signalScreenReady();
         return;
     }
 
@@ -1070,6 +1086,8 @@ function renderContent(content, styles = {}) {
         if (debugEnabled) {
             updateDebugDisplay();
         }
+        // First content paint is done — tell any embedding parent.
+        signalScreenReady();
     });
 }
 

--- a/tests/core/e2e/test_embed_ready.py
+++ b/tests/core/e2e/test_embed_ready.py
@@ -1,0 +1,55 @@
+"""E2E test for the `bbs-screen-ready` postMessage signal used by iframe embeds.
+
+When the screen viewer finishes rendering its first content, it must notify an
+embedding parent window via `postMessage({type: 'bbs-screen-ready'}, '*')` so the
+host page (e.g. the marketing site) can reveal the iframe / hide a loader.
+
+When the screen is not framed, `window.parent === window`, so the message is
+delivered to the page's own window and can be observed there.
+"""
+
+import httpx
+import pytest
+from playwright.sync_api import Page
+
+
+@pytest.fixture(scope="module")
+def demo_screen_id(app_server: str):
+    """Find the auto-created demo screen ID."""
+    with httpx.Client() as client:
+        response = client.get(f"{app_server}/api/v1/screens", params={"per_page": 100})
+        assert response.status_code == 200
+        screens = response.json().get("screens", [])
+        for screen in screens:
+            if screen.get("name") == "Welcome Demo":
+                return screen["screen_id"]
+        pytest.skip("Demo screen not found - test requires fresh database")
+
+
+def test_screen_posts_ready_message_once_rendered(
+    page: Page, app_server: str, demo_screen_id: str
+):
+    """The screen page posts `bbs-screen-ready` to its parent once content renders."""
+    # Record any messages posted to this window (parent === self when not framed).
+    page.add_init_script(
+        """
+        window.__bbsMessages = [];
+        window.addEventListener('message', (event) => {
+            window.__bbsMessages.push(event.data);
+        });
+        """
+    )
+
+    page.goto(f"{app_server}/screen/{demo_screen_id}")
+
+    # The signal fires after WebSocket sync + first render, so wait for it.
+    page.wait_for_function(
+        "() => (window.__bbsMessages || [])"
+        ".some((m) => m && m.type === 'bbs-screen-ready')"
+    )
+
+    messages = page.evaluate("() => window.__bbsMessages")
+    ready_messages = [m for m in messages if m and m.get("type") == "bbs-screen-ready"]
+    assert len(ready_messages) == 1, (
+        f"expected exactly one bbs-screen-ready message, got {ready_messages!r}"
+    )

--- a/tests/core/e2e/test_embed_ready.py
+++ b/tests/core/e2e/test_embed_ready.py
@@ -26,9 +26,7 @@ def demo_screen_id(app_server: str):
         pytest.skip("Demo screen not found - test requires fresh database")
 
 
-def test_screen_posts_ready_message_once_rendered(
-    page: Page, app_server: str, demo_screen_id: str
-):
+def test_screen_posts_ready_message_once_rendered(page: Page, app_server: str, demo_screen_id: str):
     """The screen page posts `bbs-screen-ready` to its parent once content renders."""
     # Record any messages posted to this window (parent === self when not framed).
     page.add_init_script(
@@ -44,8 +42,7 @@ def test_screen_posts_ready_message_once_rendered(
 
     # The signal fires after WebSocket sync + first render, so wait for it.
     page.wait_for_function(
-        "() => (window.__bbsMessages || [])"
-        ".some((m) => m && m.type === 'bbs-screen-ready')"
+        "() => (window.__bbsMessages || []).some((m) => m && m.type === 'bbs-screen-ready')"
     )
 
     messages = page.evaluate("() => window.__bbsMessages")

--- a/tests/core/e2e/test_embed_ready.py
+++ b/tests/core/e2e/test_embed_ready.py
@@ -47,6 +47,6 @@ def test_screen_posts_ready_message_once_rendered(page: Page, app_server: str, d
 
     messages = page.evaluate("() => window.__bbsMessages")
     ready_messages = [m for m in messages if m and m.get("type") == "bbs-screen-ready"]
-    assert len(ready_messages) == 1, (
-        f"expected exactly one bbs-screen-ready message, got {ready_messages!r}"
-    )
+    assert (
+        len(ready_messages) == 1
+    ), f"expected exactly one bbs-screen-ready message, got {ready_messages!r}"


### PR DESCRIPTION
## Summary
- Screen viewer now posts `postMessage({type:'bbs-screen-ready'}, '*')` to its parent window once the first content paint completes, so an embedding host (marketing site iframe) can reveal the iframe / hide a loader.
- Fires at most once (idempotent guard), on both the content and no-content render paths. When not framed, `window.parent === window`, so it's a harmless self-post.

## Test Plan
- [x] New e2e test `tests/core/e2e/test_embed_ready.py` — loads the demo screen, listens for the message, asserts exactly one `bbs-screen-ready` is posted. Verified red (timeout) before implementing, green after.
- [x] `pytest tests/core/unit` — 216 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)