### PR TITLE
Add show_now param and size-aware connection toast

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -205,6 +205,11 @@ class MessageRequest(BaseModel):
         "Examples: 'vertical', 'grid-2x2', 'dashboard-header', or custom config.",
         examples=["vertical", "grid-3x2", {"columns": 3, "rows": "auto 1fr 1fr"}],
     )
+    show_now: bool = Field(
+        default=False,
+        description="If true, viewers jump to this page and display it immediately, "
+        "interrupting rotation. Not persisted — affects this update only.",
+    )
 
     model_config = {
         "json_schema_extra": {
@@ -266,6 +271,11 @@ class PageRequest(BaseModel):
         ge=0,
         le=5000,
     )
+    show_now: bool = Field(
+        default=False,
+        description="If true, viewers jump to this page and display it immediately, "
+        "interrupting rotation. Not persisted — affects this update only.",
+    )
 
 
 class PageUpdateRequest(BaseModel):
@@ -289,6 +299,11 @@ class PageUpdateRequest(BaseModel):
     )
     transition_duration: int | None = Field(
         default=None, description="Transition duration in milliseconds", ge=0, le=5000
+    )
+    show_now: bool = Field(
+        default=False,
+        description="If true, viewers jump to this page and display it immediately, "
+        "interrupting rotation. Not persisted — affects this update only.",
     )
 
 

--- a/app/routes/screens.py
+++ b/app/routes/screens.py
@@ -296,7 +296,9 @@ async def send_message(
     page_data = await upsert_page(screen_id, "default", message_payload)
 
     # Broadcast page update to all connected viewers
-    viewers = await manager.broadcast(screen_id, {"type": "page_update", "page": page_data})
+    viewers = await manager.broadcast(
+        screen_id, {"type": "page_update", "page": page_data, "show_now": request.show_now}
+    )
 
     return MessageResponse(success=True, viewers=viewers)
 
@@ -753,7 +755,9 @@ async def create_or_update_page(
     )
 
     # Broadcast page update
-    viewers = await manager.broadcast(screen_id, {"type": "page_update", "page": page_data})
+    viewers = await manager.broadcast(
+        screen_id, {"type": "page_update", "page": page_data, "show_now": request.show_now}
+    )
 
     return {"success": True, "page": page_data, "viewers": viewers}
 
@@ -816,7 +820,9 @@ async def patch_page(
         raise HTTPException(status_code=404, detail="Page not found")
 
     # Broadcast page update
-    viewers = await manager.broadcast(screen_id, {"type": "page_update", "page": page_data})
+    viewers = await manager.broadcast(
+        screen_id, {"type": "page_update", "page": page_data, "show_now": request.show_now}
+    )
 
     return {"success": True, "page": page_data, "viewers": viewers}
 

--- a/docs/superpowers/specs/2026-06-27-show-now-param-design.md
+++ b/docs/superpowers/specs/2026-06-27-show-now-param-design.md
@@ -1,8 +1,13 @@
-# `show_now` Parameter — Design Spec
+# Screen Viewer: `show_now` Parameter + Responsive Connection Toast — Design Spec
 
 **Date:** 2026-06-27
 **Branch:** `feature/show-now-param`
 **Status:** Approved
+
+Two related screen-viewer changes:
+1. A `show_now` request flag to make a submitted page display immediately.
+2. Make the connection-status toast ("Connected", etc.) size-aware so it isn't
+   oversized in small/embedded viewports.
 
 ## Problem
 
@@ -66,6 +71,34 @@ persists. A `GET` of the page returns no `show_now` field.
 - Works for both brand-new pages and updates to existing pages.
 - Rotation timer resets on jump so the page isn't cut short.
 
+## Responsive connection toast
+
+### Problem
+
+The connection-status toast (`#connection-status`, styled `.connection-status` in
+`static/screen.css`) uses fixed sizing (`font-size: 1.5rem`, `padding: 1.25rem
+2.5rem`, `bottom`/`right: 2rem`, `border-radius: 3rem`). In a small embedded
+iframe this pill dominates the screen.
+
+### Design (`static/screen.css`)
+
+Replace the fixed values with fluid `clamp()` ranges keyed to `vmin`, so the toast
+scales continuously with viewport size — tiny pill in a small iframe, current size
+on a full display. No breakpoints, no JS, no markup change.
+
+```css
+.connection-status {
+    bottom: clamp(0.5rem, 3vmin, 2rem);
+    right:  clamp(0.5rem, 3vmin, 2rem);
+    padding: clamp(0.4rem, 1.6vmin, 1.25rem) clamp(0.8rem, 3.2vmin, 2.5rem);
+    font-size: clamp(0.75rem, 2.6vmin, 1.5rem);
+    border-radius: clamp(1rem, 4vmin, 3rem);
+}
+```
+
+The upper bounds equal today's values, so large screens are visually unchanged.
+Other rules (`.visible`, color variants) are untouched.
+
 ## Testing (e2e, `tests/core/e2e`)
 
 1. **Jumps on show_now:** multi-page screen, rotation on with a long interval.
@@ -73,6 +106,11 @@ persists. A `GET` of the page returns no `show_now` field.
    the rotation interval elapses.
 2. **No jump without show_now:** same setup, `show_now` omitted → viewer stays on
    the current page (does not jump to the updated page).
+3. **Toast scales down on small viewport:** load a screen at a large viewport
+   (1920×1080, where `vmin` clears the `clamp` max → computed `font-size` == 24px /
+   `1.5rem`) and at a small one (e.g. 360×640 → floors at 12px / `0.75rem`); assert
+   the small viewport's computed `font-size` is meaningfully smaller than the large
+   one's.
 
 ## Tradeoff
 

--- a/docs/superpowers/specs/2026-06-27-show-now-param-design.md
+++ b/docs/superpowers/specs/2026-06-27-show-now-param-design.md
@@ -1,0 +1,80 @@
+# `show_now` Parameter — Design Spec
+
+**Date:** 2026-06-27
+**Branch:** `feature/show-now-param`
+**Status:** Approved
+
+## Problem
+
+When a page is submitted to a screen, it only renders immediately if the screen
+is already displaying that page (matched by name). A new or non-current page is
+added to the rotation and won't appear until the carousel reaches it. There is no
+way to make a submitted page jump to the front and display right away — useful for
+alerts, "now serving" updates, or any time-sensitive content.
+
+## Goal
+
+Add an opt-in `show_now` request flag that makes the submitted page jump to the
+front and render immediately on all connected viewers, interrupting rotation.
+
+## Non-goals
+
+Persisting `show_now` on the page; a dedicated "alert" page type; priority
+ordering; honoring transitions for the jump (the jump is an instant swap).
+
+## Design
+
+`show_now` is a **transient request-time flag**. It is never written to the
+database — it only changes what connected viewers do when they receive the
+existing `page_update` broadcast.
+
+### 1. Models (`app/models.py`)
+
+Add `show_now: bool = False` to:
+
+- `MessageRequest` (the `POST /api/v1/screens/{id}/message` body)
+- `PageRequest` (the `POST /api/v1/screens/{id}/pages/{name}` body)
+- `PageUpdateRequest` (the `PATCH /api/v1/screens/{id}/pages/{name}` body)
+
+### 2. Endpoints (`app/routes/screens.py`)
+
+In `send_message`, `create_or_update_page`, and `patch_page`: after upserting the
+page, include the flag in the broadcast:
+
+```python
+{"type": "page_update", "page": page_data, "show_now": request.show_now}
+```
+
+The flag is NOT added to `message_payload` / the upsert call, so it never
+persists. A `GET` of the page returns no `show_now` field.
+
+### 3. Viewer (`static/screen.js`)
+
+- `ws.onmessage` `page_update` case calls `handlePageUpdate(data.page, data.show_now)`.
+- `handlePageUpdate(page, showNow = false)`: after upserting `page` into the
+  `pages` array, if `showNow` is true, find the page's index in the active
+  (non-expired) pages, set `currentPageIndex` to it, call `renderCurrentPage()`
+  (instant — no transition), and restart the rotation timer so the jumped-to page
+  gets its full duration before advancing.
+- When `showNow` is false/absent, behavior is unchanged (re-render only if the
+  updated page is the one currently on screen).
+
+### Edge cases
+
+- Target page not in active pages (e.g. already expired) → no-op jump; falls back
+  to default behavior.
+- Works for both brand-new pages and updates to existing pages.
+- Rotation timer resets on jump so the page isn't cut short.
+
+## Testing (e2e, `tests/core/e2e`)
+
+1. **Jumps on show_now:** multi-page screen, rotation on with a long interval.
+   Submit a non-current page with `show_now=true` → viewer displays it well before
+   the rotation interval elapses.
+2. **No jump without show_now:** same setup, `show_now` omitted → viewer stays on
+   the current page (does not jump to the updated page).
+
+## Tradeoff
+
+Instant swap ignores configured transitions for the jump. Acceptable: `show_now`
+is an interrupt, and immediacy is the point.

--- a/static/screen.css
+++ b/static/screen.css
@@ -284,11 +284,13 @@ html, body {
 /* Connection status indicator */
 .connection-status {
     position: fixed;
-    bottom: 2rem;
-    right: 2rem;
-    padding: 1.25rem 2.5rem;
-    border-radius: 3rem;
-    font-size: 1.5rem;
+    /* Fluid sizing so the toast shrinks on small/embedded viewports.
+       Upper bounds equal the original full-screen sizes. */
+    bottom: clamp(0.5rem, 3vmin, 2rem);
+    right: clamp(0.5rem, 3vmin, 2rem);
+    padding: clamp(0.4rem, 1.6vmin, 1.25rem) clamp(0.8rem, 3.2vmin, 2.5rem);
+    border-radius: clamp(1rem, 4vmin, 3rem);
+    font-size: clamp(0.75rem, 2.6vmin, 1.5rem);
     font-weight: 600;
     opacity: 0;
     transition: opacity 0.3s;

--- a/static/screen.js
+++ b/static/screen.js
@@ -134,7 +134,7 @@ function connect() {
 
             case 'page_update':
                 // Upsert single page
-                handlePageUpdate(data.page);
+                handlePageUpdate(data.page, data.show_now);
                 break;
 
             case 'page_delete':
@@ -482,7 +482,7 @@ function handlePagesSync(newPages, rotation) {
     }
 }
 
-function handlePageUpdate(page) {
+function handlePageUpdate(page, showNow = false) {
     if (!page) return;
 
     // Find existing page by name
@@ -497,8 +497,24 @@ function handlePageUpdate(page) {
         pages.sort((a, b) => a.display_order - b.display_order);
     }
 
-    // Re-render if viewing the updated page
     const activePages = getActivePages();
+
+    // show_now: jump to this page and render it immediately (instant swap),
+    // interrupting rotation. Only if the page is currently active (not expired).
+    if (showNow) {
+        const targetIndex = activePages.findIndex(p => p.name === page.name);
+        if (targetIndex >= 0) {
+            currentPageIndex = targetIndex;
+            renderCurrentPage();
+            // Restart the rotation timer so the jumped-to page gets its full duration.
+            if (rotationEnabled && pages.length > 1) {
+                startRotation();
+            }
+            return;
+        }
+    }
+
+    // Re-render if viewing the updated page
     if (activePages.length > 0 && currentPageIndex < activePages.length) {
         const currentPage = activePages[currentPageIndex];
         if (currentPage.name === page.name) {

--- a/tests/core/e2e/test_show_now.py
+++ b/tests/core/e2e/test_show_now.py
@@ -1,0 +1,110 @@
+"""E2E tests for the show_now parameter and the responsive connection toast."""
+
+import httpx
+import pytest
+from playwright.sync_api import Page, expect
+
+
+def _create_screen(app_server: str) -> dict:
+    with httpx.Client() as client:
+        response = client.post(f"{app_server}/api/v1/screens")
+        assert response.status_code == 200
+        return response.json()
+
+
+def _set_rotation(app_server: str, screen_id: str, api_key: str, enabled: bool, interval: int):
+    with httpx.Client() as client:
+        response = client.patch(
+            f"{app_server}/api/v1/screens/{screen_id}",
+            headers={"X-API-Key": api_key},
+            json={"rotation_enabled": enabled, "rotation_interval": interval},
+        )
+        assert response.status_code == 200
+
+
+def _put_page(
+    app_server: str,
+    screen_id: str,
+    api_key: str,
+    name: str,
+    content: list,
+    show_now: bool | None = None,
+):
+    body: dict = {"content": content}
+    if show_now is not None:
+        body["show_now"] = show_now
+    with httpx.Client() as client:
+        response = client.post(
+            f"{app_server}/api/v1/screens/{screen_id}/pages/{name}",
+            headers={"X-API-Key": api_key},
+            json=body,
+        )
+        assert response.status_code == 200
+
+
+class TestShowNow:
+    """The show_now flag makes a submitted page display immediately."""
+
+    @pytest.fixture
+    def screen(self, app_server: str) -> dict:
+        return _create_screen(app_server)
+
+    def test_show_now_jumps_to_page_immediately(self, page: Page, app_server: str, screen: dict):
+        sid, key = screen["screen_id"], screen["api_key"]
+        _set_rotation(app_server, sid, key, True, 3600)
+        _put_page(app_server, sid, key, "alpha", ["ALPHA PAGE"])
+
+        page.goto(f"{app_server}/screen/{sid}")
+        expect(page.locator("text=ALPHA PAGE")).to_be_visible()
+        # Let the WebSocket settle so the next broadcast arrives live.
+        page.wait_for_timeout(500)
+
+        # A new, non-current page should only surface via show_now.
+        _put_page(app_server, sid, key, "beta", ["BETA PAGE"], show_now=True)
+
+        expect(page.locator("text=BETA PAGE")).to_be_visible()
+
+    def test_without_show_now_does_not_jump(self, page: Page, app_server: str, screen: dict):
+        sid, key = screen["screen_id"], screen["api_key"]
+        _set_rotation(app_server, sid, key, True, 3600)
+        _put_page(app_server, sid, key, "alpha", ["ALPHA PAGE"])
+
+        page.goto(f"{app_server}/screen/{sid}")
+        expect(page.locator("text=ALPHA PAGE")).to_be_visible()
+        page.wait_for_timeout(500)
+
+        # Submit a new page without show_now — the view must not jump to it.
+        _put_page(app_server, sid, key, "gamma", ["GAMMA PAGE"])
+
+        page.wait_for_timeout(1000)
+        expect(page.locator("text=ALPHA PAGE")).to_be_visible()
+        expect(page.locator("text=GAMMA PAGE")).to_have_count(0)
+
+
+class TestResponsiveToast:
+    """The connection toast scales down on small viewports."""
+
+    @pytest.fixture
+    def screen(self, app_server: str) -> dict:
+        return _create_screen(app_server)
+
+    def test_toast_scales_down_on_small_viewport(self, page: Page, app_server: str, screen: dict):
+        sid = screen["screen_id"]
+
+        def toast_font_px() -> float:
+            return page.evaluate(
+                "() => parseFloat(getComputedStyle("
+                "document.getElementById('connection-status')).fontSize)"
+            )
+
+        page.set_viewport_size({"width": 1920, "height": 1080})
+        page.goto(f"{app_server}/screen/{sid}")
+        expect(page.locator("#connection-status")).to_be_attached()
+        large = toast_font_px()
+
+        page.set_viewport_size({"width": 360, "height": 640})
+        small = toast_font_px()
+
+        assert large == pytest.approx(24, abs=1)  # clamp max == 1.5rem
+        assert small < large
+        assert small <= 14


### PR DESCRIPTION
## Summary
- **`show_now` parameter** on all three page-write endpoints (`POST /message`, `POST /pages/{name}`, `PATCH /pages/{name}`). When `true`, connected viewers jump to the submitted page and render it immediately (instant swap), interrupting rotation. Passed through the existing `page_update` broadcast; **not persisted** to the DB.
- **Size-aware connection toast** — `.connection-status` now uses `clamp()`/`vmin` sizing so the "Connected" pill scales down on small/embedded viewports. Upper bounds equal the previous full-screen sizes, so large displays are unchanged.

Spec: `docs/superpowers/specs/2026-06-27-show-now-param-design.md`

## Test Plan
- [x] New e2e `tests/core/e2e/test_show_now.py`: jump-on-`show_now`, no-jump-without, toast font-size shrinks on small viewport (watched fail before, pass after).
- [x] `pytest tests/core/unit` — 216 passed; `tests/saas/unit` — 34 passed
- [x] Existing `TestConnectionStatus` e2e — 3 passed (toast change non-breaking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)