### PR TITLE
Document show_now param in API docs

### DIFF
--- a/docs/api/messages.md
+++ b/docs/api/messages.md
@@ -29,6 +29,7 @@ POST /api/v1/screens/{screen_id}/message
 | `gap` | string | Space between panels |
 | `border_radius` | string | Panel corner radius |
 | `panel_shadow` | string | Panel box-shadow |
+| `show_now` | boolean | If `true`, viewers display this update immediately, interrupting rotation (default `false`). Not persisted. |
 
 ## Simple Text
 

--- a/docs/api/pages.md
+++ b/docs/api/pages.md
@@ -67,6 +67,7 @@ POST /api/v1/screens/{screen_id}/pages/{page_name}
 | `expires_at` | string | ISO timestamp for auto-expiry |
 | `transition` | string | Transition effect when entering page: `"none"`, `"fade"`, `"slide-left"` |
 | `transition_duration` | integer | Transition duration in milliseconds (0-5000) |
+| `show_now` | boolean | If `true`, viewers jump to this page and display it immediately, interrupting rotation (default `false`). Not persisted. |
 | `background_color` | string | Page background color |
 | `panel_color` | string | Page panel color |
 | `font_family` | string | Page font family |


### PR DESCRIPTION
## Summary
Add a `show_now` row to the body-parameter tables in `docs/api/messages.md` and `docs/api/pages.md`, documenting the flag added in #24. (The interactive Swagger docs already reflect it via the model field descriptions.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)