### PR TITLE
Expose show_now via MCP send_message and create_page

### DIFF
--- a/app/mcp/arg_models.py
+++ b/app/mcp/arg_models.py
@@ -112,6 +112,11 @@ class SendMessageArgs(BaseModel):
         default=None, description="Panel corner rounding (CSS length)"
     )
     panel_shadow: str | None = Field(default=None, description="Panel drop shadow (CSS box-shadow)")
+    show_now: bool = Field(
+        default=False,
+        description="If true, viewers display this update immediately, interrupting rotation. "
+        "Not persisted.",
+    )
 
 
 class CreatePageArgs(BaseModel):
@@ -148,6 +153,11 @@ class CreatePageArgs(BaseModel):
     )
     transition_duration: int | None = Field(
         default=None, description="Transition duration in milliseconds", ge=0, le=5000
+    )
+    show_now: bool = Field(
+        default=False,
+        description="If true, viewers jump to this page and display it immediately, "
+        "interrupting rotation. Not persisted.",
     )
 
 

--- a/app/mcp/handlers.py
+++ b/app/mcp/handlers.py
@@ -411,7 +411,9 @@ async def handle_send_message(arguments: dict[str, Any]) -> dict[str, Any]:
 
     page_data = await upsert_page(screen_id, "default", message_payload)
 
-    viewers = await manager.broadcast(screen_id, {"type": "page_update", "page": page_data})
+    viewers = await manager.broadcast(
+        screen_id, {"type": "page_update", "page": page_data, "show_now": args.show_now}
+    )
 
     return {"success": True, "viewers": viewers}
 
@@ -458,7 +460,9 @@ async def handle_create_page(arguments: dict[str, Any]) -> dict[str, Any]:
 
     page_data = await upsert_page(screen_id, page_name, message_payload, duration=duration)
 
-    viewers = await manager.broadcast(screen_id, {"type": "page_update", "page": page_data})
+    viewers = await manager.broadcast(
+        screen_id, {"type": "page_update", "page": page_data, "show_now": args.show_now}
+    )
 
     return {"success": True, "page": page_data, "viewers": viewers}
 

--- a/docs/api/mcp-server.md
+++ b/docs/api/mcp-server.md
@@ -236,6 +236,7 @@ Send content to a screen's default page.
 | `panel_color` | string | No | Panel color |
 | `font_family` | string | No | Font family |
 | `font_color` | string | No | Text color |
+| `show_now` | boolean | No | Display this update immediately, interrupting rotation (default `false`) |
 
 **Content Types:**
 
@@ -270,6 +271,7 @@ Create or update a named page for rotation.
 | `background_color` | string | No | Page background color |
 | `panel_color` | string | No | Page panel color |
 | `transition` | string | No | Transition effect |
+| `show_now` | boolean | No | Jump to this page and display it immediately, interrupting rotation (default `false`) |
 
 **Example:**
 

--- a/tests/core/unit/test_mcp.py
+++ b/tests/core/unit/test_mcp.py
@@ -137,6 +137,20 @@ class TestMCPTools:
         assert "content" in tool.inputSchema["required"]
         assert "duration" in tool.inputSchema["properties"]
 
+    def test_send_message_tool_exposes_show_now(self):
+        """send_message tool advertises the show_now parameter."""
+        from app.mcp.tools import send_message_tool
+
+        tool = send_message_tool()
+        assert "show_now" in tool.inputSchema["properties"]
+
+    def test_create_page_tool_exposes_show_now(self):
+        """create_page tool advertises the show_now parameter."""
+        from app.mcp.tools import create_page_tool
+
+        tool = create_page_tool()
+        assert "show_now" in tool.inputSchema["properties"]
+
     def test_list_layouts_tool(self):
         """Test list_layouts tool definition."""
         from app.mcp.tools import list_layouts_tool
@@ -324,6 +338,59 @@ class TestMCPHandlers:
         )
         assert result["success"] is True
         assert result["page"]["duration"] == 15
+
+    def test_handle_send_message_show_now_in_broadcast(self, setup_test_db, monkeypatch):
+        """send_message handler forwards show_now in the page_update broadcast."""
+        from app.mcp import handlers
+        from app.mcp.handlers import handle_create_screen, handle_send_message
+
+        captured = {}
+
+        async def fake_broadcast(screen_id, payload):
+            captured["payload"] = payload
+            return 0
+
+        monkeypatch.setattr(handlers.manager, "broadcast", fake_broadcast)
+
+        screen = _run_coro(handle_create_screen({}))
+        _run_coro(
+            handle_send_message(
+                {
+                    "screen_id": screen["screen_id"],
+                    "api_key": screen["api_key"],
+                    "content": ["urgent"],
+                    "show_now": True,
+                }
+            )
+        )
+        assert captured["payload"]["show_now"] is True
+
+    def test_handle_create_page_show_now_in_broadcast(self, setup_test_db, monkeypatch):
+        """create_page handler forwards show_now in the page_update broadcast."""
+        from app.mcp import handlers
+        from app.mcp.handlers import handle_create_page, handle_create_screen
+
+        captured = {}
+
+        async def fake_broadcast(screen_id, payload):
+            captured["payload"] = payload
+            return 0
+
+        monkeypatch.setattr(handlers.manager, "broadcast", fake_broadcast)
+
+        screen = _run_coro(handle_create_screen({}))
+        _run_coro(
+            handle_create_page(
+                {
+                    "screen_id": screen["screen_id"],
+                    "page_name": "alerts",
+                    "api_key": screen["api_key"],
+                    "content": ["Alert!"],
+                    "show_now": True,
+                }
+            )
+        )
+        assert captured["payload"]["show_now"] is True
 
     def test_handle_update_screen(self, setup_test_db):
         """Test update_screen handler."""


### PR DESCRIPTION
## Summary
Follow-up to #24: the MCP server is a separate interface from the REST API (its own arg models + handlers), so it didn't pick up the `show_now` flag. This adds it:
- `show_now` added to `SendMessageArgs` and `CreatePageArgs` (auto-advertised in each tool's `inputSchema`).
- Forwarded through both `page_update` broadcasts in `app/mcp/handlers.py`.
- MCP docs updated (`docs/api/mcp-server.md`).

MCP clients can now make a page display immediately, matching REST.

## Test Plan
- [x] New unit tests in `tests/core/unit/test_mcp.py`: both tools expose `show_now`; both handlers forward it in the broadcast (watched fail, then pass).
- [x] `pytest tests/core/unit` — 220 passed; `tests/saas/unit` — 34 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)