### PR TITLE
Gitignore .playwright-mcp artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,9 @@ node_modules/
 *.sw?
 # OS specific
 
+# Playwright MCP browser-session artifacts
+.playwright-mcp/
+
 # Task files
 # tasks.json
 # tasks/ 


### PR DESCRIPTION
Adds `.playwright-mcp/` (Playwright MCP browser-session artifacts) to `.gitignore` so it stops showing up as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)