### PR TITLE
Fix 500 on page expires_at in Postgres (string vs TIMESTAMPTZ)

### DIFF
--- a/app/db/postgres.py
+++ b/app/db/postgres.py
@@ -15,6 +15,21 @@ from ..themes import get_builtin_themes, get_theme
 from .base import DatabaseBackend
 
 
+def _to_timestamptz(value: str | datetime | None) -> datetime | None:
+    """Coerce an ISO-8601 string (or datetime) to a tz-aware datetime for asyncpg.
+
+    The page-write layer passes `expires_at` as an ISO string, but asyncpg binds
+    it to a TIMESTAMPTZ column and requires a `datetime`. Naive values are assumed
+    to be UTC.
+    """
+    if value is None:
+        return None
+    dt = value if isinstance(value, datetime) else datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt
+
+
 class PostgresBackend(DatabaseBackend):
     """PostgreSQL implementation of the database backend."""
 
@@ -603,6 +618,7 @@ class PostgresBackend(DatabaseBackend):
     ) -> dict:
         """Create or update a page."""
         now = datetime.now(UTC)
+        expires_at_ts = _to_timestamptz(expires_at)
         pool = await self._get_pool()
 
         async with pool.acquire() as conn:
@@ -621,7 +637,7 @@ class PostgresBackend(DatabaseBackend):
                 """,
                     json.dumps(payload),
                     duration,
-                    expires_at,
+                    expires_at_ts,
                     now,
                     screen_id,
                     name,
@@ -644,7 +660,7 @@ class PostgresBackend(DatabaseBackend):
                     json.dumps(payload),
                     display_order,
                     duration,
-                    expires_at,
+                    expires_at_ts,
                     now,
                 )
 
@@ -806,7 +822,9 @@ class PostgresBackend(DatabaseBackend):
                 existing_data["transition_duration"] = transition_duration
 
             new_duration = duration if duration is not None else row["duration"]
-            new_expires_at = expires_at if expires_at is not None else row["expires_at"]
+            new_expires_at = (
+                _to_timestamptz(expires_at) if expires_at is not None else row["expires_at"]
+            )
 
             await conn.execute(
                 """

--- a/tests/core/unit/test_postgres_expires_at.py
+++ b/tests/core/unit/test_postgres_expires_at.py
@@ -1,0 +1,41 @@
+"""Unit tests for the Postgres timestamp coercion used by page expires_at.
+
+Regression: the page-write endpoints pass `expires_at` as an ISO-8601 *string*
+(`request.expires_at.isoformat()`). asyncpg requires a `datetime` for the
+TIMESTAMPTZ column, so binding the raw string raised and produced a 500 on
+POST/PATCH /pages/{name}. The backend must coerce the string to a tz-aware
+datetime before binding.
+"""
+
+from datetime import UTC, datetime
+
+from app.db.postgres import _to_timestamptz
+
+
+def test_none_returns_none():
+    assert _to_timestamptz(None) is None
+
+
+def test_iso_utc_string_parsed_to_aware_datetime():
+    # What the endpoint actually sends: request.expires_at.isoformat() for a UTC value.
+    dt = _to_timestamptz("2026-06-28T02:16:42.987000+00:00")
+    assert isinstance(dt, datetime)
+    assert dt.tzinfo is not None
+    assert dt == datetime(2026, 6, 28, 2, 16, 42, 987000, tzinfo=UTC)
+
+
+def test_naive_iso_string_assumed_utc():
+    dt = _to_timestamptz("2026-06-28T03:00:00")
+    assert dt.tzinfo is not None
+    assert dt == datetime(2026, 6, 28, 3, 0, 0, tzinfo=UTC)
+
+
+def test_existing_datetime_made_aware():
+    dt = _to_timestamptz(datetime(2026, 6, 28, 3, 0, 0))
+    assert dt.tzinfo is not None
+    assert dt == datetime(2026, 6, 28, 3, 0, 0, tzinfo=UTC)
+
+
+def test_aware_datetime_passthrough():
+    aware = datetime(2026, 6, 28, 3, 0, 0, tzinfo=UTC)
+    assert _to_timestamptz(aware) == aware


### PR DESCRIPTION
## Problem
Every non-null `expires_at` on `POST`/`PATCH /pages/{name}` returned **500** in SaaS mode (Postgres), for all formats (ISO with/without ms, offset, naive, date-only, epoch). Only `null` worked. Self-hosted (SQLite) was unaffected, so it slipped past the e2e tests.

## Root cause
The endpoints pass `expires_at` as an ISO-8601 **string** (`request.expires_at.isoformat()`). SQLite stores it in a TEXT column (fine), but `pages.expires_at` in Postgres is `TIMESTAMPTZ` and **asyncpg rejects a `str`** for a timestamp parameter → 500. (`created_at`/`updated_at` worked because they bind a real `datetime.now(UTC)`.)

## Fix
Add `_to_timestamptz()` in `app/db/postgres.py` to coerce the ISO string (or datetime) to a **tz-aware datetime** (naive assumed UTC), and bind that in `upsert_page` and `update_page`. The returned `page_data` keeps `expires_at` as the ISO string so the `page_update` websocket broadcast stays JSON-serializable.

## Test Plan
- [x] New unit tests `tests/core/unit/test_postgres_expires_at.py` covering the coercion (None, ISO-UTC, naive→UTC, datetime passthrough). Watched fail (helper missing) → pass.
- [x] `pytest tests/core/unit` — 225 passed; `tests/saas/unit` — 34 passed
- [ ] Post-deploy: verify on dev that `POST /pages/{name}` with an ISO `expires_at` returns 200 (asyncpg binding can't be exercised without a live Postgres).

🤖 Generated with [Claude Code](https://claude.com/claude-code)